### PR TITLE
New version 0.0.16

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -63,11 +63,17 @@ Instance.prototype._stubFunc = function(prop){
       return this._doc[prop];
     },
     set: function (value) {
-      if (!_.isEqual(this._doc[prop],value)) {
+      var theVal = value;
+      var schemaItem = this._internalState.m_schema[prop];
+      if (schemaItem) {
+        theVal = this._toObject(value, schemaItem);
+      }
+      if (!_.isEqual(this._doc[prop], theVal)) {
         this._internalState.m_isDirty = true;
         this._internalState.m_dirtyFields.push(prop);
-        this._doc[prop] = value;
+        this._doc[prop] = theVal;
       }
+      // TODO: this won't work right for types.MAP and types.LIST - see _loadProperty - the logic of _loadProperty needs to be called in the setter
     }
   };
 };
@@ -108,12 +114,12 @@ Instance.prototype._loadProperty = function(schemaItem, property, value) {
   }
 };
 
-Instance.prototype._toObject = function(prop, schema) {
+Instance.prototype._toObject = function(value, schema) {
   if(schema.type.toObject) {
-    return schema.type.toObject(prop, schema.type, schema);
+    return schema.type.toObject(value, schema.type, schema);
   }
   else
-    return prop;
+    return value;
 };
 
 Instance.prototype._createProperties = function(props) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -174,7 +174,8 @@ module.exports = function(instance, opts) {
       }
       else
       {
-        //TODO: run post commands
+        instance._markClean();
+        instance._runPost();
         if(utility.isFunction(cb))
           cb(null, instance);
       }
@@ -209,6 +210,7 @@ module.exports = function(instance, opts) {
       }
       else
       {
+        instance._markClean();
         instance._runPost();
         if(utility.isFunction(cb))
           cb(null, instance);

--- a/lib/types.js
+++ b/lib/types.js
@@ -94,10 +94,10 @@ types.prototype.TIMESTAMP = function() {
   ];
 
   function toCQLString(obj, insert) {
-    return moment(obj).format();
+    return moment(obj).utc().format(); // This clones the underlying moment object, puts it in utc mode, and the returns date as UTC string
   }
   function toObject(obj) {
-    return moment(obj).toString();
+    return moment.utc(obj);
   }
   function validate(obj, userValidators) {
     var vArr = validators.concat(userValidators);
@@ -296,8 +296,11 @@ types.prototype.ENUMTOTEXT = function() {
     var result = util.validateAll(obj, vArr);
     return result;
   }
-  function toObject(obj,type, schema) {
-    return schema.enumerator.FromValue(obj);
+  function toObject(obj, type, schema) {
+    if (typeof obj === 'string') {
+      return schema.enumerator.FromValue(obj);
+    }
+    return obj;
   }
   return {
     toCQLString: toCQLString,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqlify",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Cassandra CQL ORM",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Made date fields use moment objects internally and always use UTC when sending to Cassandra
Made sure that Types.toObject is called when an instance setter is invoked
Added markClean after insert and update
